### PR TITLE
fix: fix issue#1, remove the background color after autofill

### DIFF
--- a/src/views/users/UserLogin.vue
+++ b/src/views/users/UserLogin.vue
@@ -210,4 +210,9 @@ const handleSubmit = e => {
     cursor: pointer;
   }
 }
+
+.n-input:deep(input.n-input__input-el:autofill),
+.n-input:deep(input.n-input__input-el:-webkit-autofill) {
+  transition: background-color 9999s ease-in-out 9999999s !important;
+}
 </style>


### PR DESCRIPTION
# What problem does this PR solve?
Issue Number: #1 
Problem Summary: To remove the background color in input boxes after auto-fill

# What is changed and how it works?
What's Changed: File `src/views/users/UserLogin.vue` from line 213 to line 217. (5+)

# How it Works:
To delay the background color transition using pseudo classes `:autofill` and `:-webkit-autofill`, the delay time is set to be too long to actually take place.
![image](https://github.com/opencurve/curve-dashboard/assets/85970705/db47a631-4bb2-48f2-b3e9-e759e69cbde3)
![image](https://github.com/opencurve/curve-dashboard/assets/85970705/bc600f80-da59-4ff9-ac03-40b893368a51)
![image](https://github.com/opencurve/curve-dashboard/assets/85970705/61fb4d19-d248-4070-9a46-5d3e013331b9)


# Side effects(Breaking backward compatibility? Performance regression?):
No side effect at the moment / no performance regression. / Tested on Edge, Chrome and Firefox. / Testing on Safari is not done because I don't have a suitable device.

# P.S. 
A longer description on this issue (in Chinese) can be find on my notion: 
https://cuiyikai.notion.site/PR-report-Background-color-removal-of-auto-filled-input-box-using-CSS-ef6a350da2ea403ba478aa4a01245389?pvs=4