### PR TITLE
fix: Added unallocated capacity legend to homepage cluster capacity p…

### DIFF
--- a/src/charts/cluster-overview/ClusterSpaceChart.vue
+++ b/src/charts/cluster-overview/ClusterSpaceChart.vue
@@ -78,7 +78,10 @@ const drawChart = () => {
       legend: {
         bottom: 10,
         left: 'center',
-        data: ['已分配不可回收容量', '已分配可回收容量'],
+        data: ['已分配不可回收容量', '已分配可回收容量','未分配容量'],
+        formatter: function (name: string) {
+          return name.length > 10 ? name.substr(0, 10) + '...' : name
+        }
       },
     }
     myChart.value.setOption(option)


### PR DESCRIPTION
# What problem does this PR solve?

Issue Number: #4 

The legend for unallocated capacity is missing

![image](https://github.com/opencurve/curve-dashboard/assets/89851138/178f121b-cf1a-403e-b759-2f86262b3fa6)

Final result after repair

![image](https://github.com/opencurve/curve-dashboard/assets/89851138/e315e09a-d706-44cb-9247-d8fbc7a8e9e4)
